### PR TITLE
Tag with ship

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -76,3 +76,4 @@ runtime_flag=${LAMBDA_RUNTIME:+"--runtime $LAMBDA_RUNTIME"}
   --container_name $CONTAINER_NAME \
   --hq $HEADQUARTERS_REMOTE \
   --account $AWS_ACCOUNT_NUMBER
+  --ship $SHIP_NAME

--- a/bin/compile
+++ b/bin/compile
@@ -75,5 +75,5 @@ runtime_flag=${LAMBDA_RUNTIME:+"--runtime $LAMBDA_RUNTIME"}
   --service $ORDERS_NAME \
   --container_name $CONTAINER_NAME \
   --hq $HEADQUARTERS_REMOTE \
-  --account $AWS_ACCOUNT_NUMBER
+  --account $AWS_ACCOUNT_NUMBER \
   --ship $SHIP_NAME

--- a/src/deployer/cli.js
+++ b/src/deployer/cli.js
@@ -9,6 +9,7 @@ program
   .option('-n, --container_name <container_name>', 'The name of the lxc container in which we are running' )
   .option('-h, --hq <hq>', 'location of the git remote for the headquarters ' )
   .option('-a, --account <account>', 'account ID of the AWS account being deployed to ' )
+  .option('--ship <ship>', 'Name of the ship that has built this deployment.  Takes the form ip-172-121-12-11 ' )
 ;
 
 module.exports = argv => {
@@ -44,6 +45,9 @@ module.exports = argv => {
       console.log('You must specify HQ Remote using the --hq or -h option')
       process.exit(1)
   }
-
+  if (typeof params.ship == 'undefined'){
+    console.log('You must specify the ship name using the --ship option')
+    process.exit(1)
+}
   return params;
 };

--- a/src/deployer/parse-orders-file.js
+++ b/src/deployer/parse-orders-file.js
@@ -35,6 +35,7 @@ const data = {
   aws_role: roleIndex > -1 ? parsedOrders[roleIndex].value : 'lambda-deploy-function-role',
   // defaults to private
   aws_private: securityIndex === -1 ? true : parsedOrders[roleIndex].value.toLower() !== 'public',
+  ship_name: program.ship
 };
 
 // just for debug purposes

--- a/src/deployer/templates/aws-node-serverless.yml.mst
+++ b/src/deployer/templates/aws-node-serverless.yml.mst
@@ -46,6 +46,7 @@ provider:
   stackTags:
     Type: starphleet-lambda
     ServiceName: {{ service_name }}
+    ShipName: {{ ship_name }}
 functions:
   api:
     handler: lambda_index.handler


### PR DESCRIPTION
Add Tag to CloudFormation Stack the denote the Starphleet Ship that built and deployed that stack.  This will be used to determine when a particular stack can be deleted (reaped)